### PR TITLE
Add docs and default value for title setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The [config.json](https://github.com/QuickPay/standard-branding/tree/master/conf
 
 Currently it supports:
 
+* `title` (string, default: null), when set, uses the value as HTML title in the payment window. Otherwise the merchant shop name is used.
 * `enable_card_holder_field` (boolean, default: false), adds "Card holder name" input field to the credit/debit card form.
 * `enable_3d_card_field` (boolean, default: false), adds a checkbox for letting card holder force 3D Secure on payment.
 

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
+  "title": null,
   "enable_card_holder_field": false,
   "enable_3d_card_field": false
 }


### PR DESCRIPTION
Ref https://github.com/QuickPay/payment/pull/475

Docs and default value for new `title` setting.
This is not needed for the payment part to work, since the default value is `null`, which is also the implicit value if the setting is not present.