### PR TITLE
Remove default config so that merchant may override them

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ Currently it supports:
 
 The configuration can be access using a Liquid Drop `config` - example: `{% if config.enable_3d_card_field %}`
 
+Example config file:
+
+```json
+{
+  "title": "My Webshop Inc.",
+  "enable_card_holder_field": false,
+  "enable_3d_card_field": false,
+  "autojump": true,
+  "my_own_custom_key": "Access this value in a template with {% config.my_own_custom_key %}"
+}
+```
+
 
 ## Language and Translation <a style="float: right" href="https://translate.quickpay.net/projects/quickpay/standard-branding-v2xx/"><img src="http://translate.quickpay.net/widgets/quickpay/-/shields-badge.svg" alt="Translation status" /></a>
 

--- a/config.json
+++ b/config.json
@@ -1,6 +1,2 @@
 {
-  "title": null,
-  "enable_card_holder_field": false,
-  "enable_3d_card_field": false,
-  "autojump": false
 }


### PR DESCRIPTION
To let merchants override config with a set of defauilt configs, we need to remove defaults from the standard-branding.