### PR TITLE
removed email field from trustly payment_#791

### DIFF
--- a/templates/form/trustly.liquid
+++ b/templates/form/trustly.liquid
@@ -37,13 +37,6 @@
 
           <div class="form-group">
             <div class="col-xs-12">
-              <label for="email" class="control-label">{% t Email %}</label>
-              <input type="text" id="email" name="person[email]" class="form-control" autocomplete="on" required>
-            </div>
-          </div>
-
-          <div class="form-group">
-            <div class="col-xs-12">
               <button type="submit" class="btn btn-info btn">{% t Proceed %}</button>
             </div>
           </div>

--- a/templates/form/trustly_ideal.liquid
+++ b/templates/form/trustly_ideal.liquid
@@ -37,13 +37,6 @@
 
           <div class="form-group">
             <div class="col-xs-12">
-              <label for="email" class="control-label">{% t Email %}</label>
-              <input type="text" id="email" name="person[email]" class="form-control" autocomplete="on" required>
-            </div>
-          </div>
-
-          <div class="form-group">
-            <div class="col-xs-12">
               <button type="submit" class="btn btn-info btn">{% t Proceed %}</button>
             </div>
           </div>


### PR DESCRIPTION
[Payment #791](https://github.com/QuickPay/payment/issues/791)
Removed email from the trustly form at payment page


## Pre-Deployment Tasks

In the following order

[API](https://github.com/QuickPay/api/pull/3485)

[Payment](https://github.com/QuickPay/payment/pull/838)