### PR TITLE
Swish form should not auto submit

### DIFF
--- a/templates/form/swish.liquid
+++ b/templates/form/swish.liquid
@@ -10,7 +10,7 @@
         <div class="form-group">
           <div class="col-xs-12">
             <label for="mobile" class="control-label">{% t Mobile number %}</label>
-            <input type="tel" id="mobile" name="mobile" class="form-control" autocomplete="tel" pattern="[0-9\s]*" inputmode="numeric">
+            <input type="tel" id="mobile" name="mobile" class="form-control" autocomplete="tel" pattern="[0-9\s]*" inputmode="numeric" value="{{ model.mobile_number }}">
           </div>
         </div>
 


### PR DESCRIPTION
[Payment#891](https://github.com/QuickPay/payment/issues/891)

Swish form should pick invoice mobile/phone number and not auto submit the form.


Before deployment:

[Payment_pull#893](https://github.com/QuickPay/payment/pull/893) should be deployed
