### PR TITLE
branding config to allow merchant to show amount for subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Currently it supports:
 * `title` (string, default: null), when set, uses the value as HTML title in the payment window. Otherwise the merchant shop name is used.
 * `enable_card_holder_field` (boolean, default: false), adds "Card holder name" input field to the credit/debit card form.
 * `enable_3d_card_field` (boolean, default: false), adds a checkbox for letting card holder force 3D Secure on payment.
+* `enable_amount_for_subscription` (boolean, default: false), displays amount while creating the subscription.
 * `autojump` (boolean, default: false), makes the cursor autojump to the next field when entering card information.
 
 The configuration can be access using a Liquid Drop `config` - example: `{% if config.enable_3d_card_field %}`
@@ -31,6 +32,7 @@ Example config file:
   "title": "My Webshop Inc.",
   "enable_card_holder_field": false,
   "enable_3d_card_field": false,
+  "enable_amount_for_subscription": false,
   "autojump": true,
   "my_own_custom_key": "Access this value in a template with {% config.my_own_custom_key %}"
 }

--- a/templates/form/card.liquid
+++ b/templates/form/card.liquid
@@ -79,6 +79,9 @@
                 {% t Pay %} <span id="total-field">{{ model.formatted_amount }} {{ model.currency }}</span>
               {% elsif model.transaction_type == "subscription" %}
                 {% t Create subscription %}
+                {% if config.enable_amount_for_subscription %}
+                  <span id="total-field"> ({{ model.formatted_amount }} {{ model.currency }})</span>
+                {% endif %}
               {% elsif model.transaction_type == "card" %}
                 {% t Save card %}
               {% elsif model.transaction_type == "payout" %}


### PR DESCRIPTION
#69 

added branding config "enable_amount_for_subscription" which allows merchant to show amount for subscriptions.

**Pre-Deployment Task**

[https://github.com/QuickPay/payment/pull/922](https://github.com/QuickPay/payment/pull/922)
