### PR TITLE
added placeholder for swish mobile number input box

### DIFF
--- a/templates/form/swish.liquid
+++ b/templates/form/swish.liquid
@@ -10,7 +10,7 @@
         <div class="form-group">
           <div class="col-xs-12">
             <label for="mobile" class="control-label">{% t Mobile number %}</label>
-            <input type="tel" id="mobile" name="mobile" class="form-control" autocomplete="tel" pattern="[0-9\s]*" inputmode="numeric" value="{{ model.mobile_number }}">
+            <input type="tel" id="mobile" name="mobile" class="form-control" autocomplete="tel" pattern="[0-9\s]*" inputmode="numeric" value="{{ model.mobile_number }}" placeholder="07XXXXXX">
           </div>
         </div>
 


### PR DESCRIPTION
#67 
Added placeholder for swish mobile number input box.

![image](https://user-images.githubusercontent.com/68404/111563503-17eee400-87be-11eb-942f-3b8d6ee18d1b.png)
