### PR TITLE
added range for - upto 9th digit in swish form for mobile number

### DIFF
--- a/templates/form/swish.liquid
+++ b/templates/form/swish.liquid
@@ -10,7 +10,17 @@
         <div class="form-group">
           <div class="col-xs-12">
             <label for="mobile" class="control-label">{% t Mobile number %}</label>
-            <input type="tel" id="mobile" name="mobile" class="form-control" autocomplete="tel" pattern="^\s*(?:\+?(\d{1,2}))?[-. (]*[0-9\s]*" inputmode="numeric" value="{{ model.mobile_number }}" placeholder="07XXXXXX">
+            <input
+              type="tel"
+              id="mobile"
+              name="mobile"
+              class="form-control"
+              autocomplete="tel"
+              pattern="^\s*(?:\+?(\d{1,9}))?[-. (]*[0-9\s]*"
+              inputmode="numeric"
+              value="{{ model.mobile_number }}"
+              placeholder="07XXXXXX"
+            />
           </div>
         </div>
 


### PR DESCRIPTION
#86 
"-" can be placed at any place in mobile number now but only before spaces else, it will become invalid number.

Previously, it was acceptable till 3 digits. e.g +879-XXX XXX.

