### PR TITLE
Added support for select of card brand

### DIFF
--- a/stylesheets/paymentwindow.css
+++ b/stylesheets/paymentwindow.css
@@ -57,6 +57,11 @@ input[type="text"], input[type="tel"], input[type="number"] {
   letter-spacing: 1.2px;
 }
 
+input[type="radio"] {
+  margin-top: -1px;
+  vertical-align: middle;
+}
+
 select {
   line-height: 16px !important;
   font-size: 16px !important;
@@ -214,6 +219,11 @@ a.btn, button[type="submit"] {
 #active-form .form-control-feedback img.check-icon {
   width: 20px;
   height: 20px;
+}
+
+.inline-option {
+  display: inline-block;
+  margin: 0 0 0 10px;
 }
 
 #active-form #cvd-help img {

--- a/templates/form/card.liquid
+++ b/templates/form/card.liquid
@@ -29,6 +29,24 @@
           </div>
         </div>
 
+        <div id="brand-selector" class="form-group has-feedback" style="display: none;">
+          <div class="col-xs-12">
+            <span>{% t Card type %}:</span>
+            <div class="inline-option">
+            <input type="radio" name="brand" id="cardbrandVisa" value="visa">
+            <label for="cardbrandVisa">
+              Visa
+            </label>
+            </div>
+            <div class="inline-option">
+            <input type="radio" name="brand" id="cardbrandDankort" value="dankort">
+            <label for="cardbrandDankort">
+              Dankort
+            </label>
+            </div>
+          </div>
+        </div>
+
         <div class="form-group has-feedback">
           <div class="col-xs-6">
 


### PR DESCRIPTION
Frontend part of issue: https://unz.atlassian.net/wiki/spaces/UQ/pages/1148453205/Select+brand+of+co-branded+cards+in+PW 
Backend found here: https://github.com/QuickPay/payment/pull/1251 

I added the option to select either Dankort or Visa when using a Visa/Dankort card number. 
The option should only show up after inputting a Visa/Dankort number and if you have Nets enabled as an acquirer. 
Additional info on testing can be found on the backend PR.

This should only be released after https://github.com/QuickPay/payment/pull/1251 