### PR TITLE
Added PayPal Javascript-SDK to Payment

### DIFF
--- a/templates/form/paypalpayments.liquid
+++ b/templates/form/paypalpayments.liquid
@@ -3,10 +3,6 @@
     <div id="paypal-button-container"></div>
   </form>
   <form method="GET" target="_top" id="redirect-form" style="visibility:hidden;">
-    {% for field in model.params %}
-      <input type="hidden" name="{{ field[0] }}" value="{{ field[1] }}" />
-    {% endfor %}
-
     <div class="row">
       <div class="col-sm-4 col-sm-push-8 col-xs-6 col-xs-push-3">
           <img src="/assets/v2/images/brands/paypal-payments.svg" alt="PayPalPayments" title="PayPalPayments" style="width:100%">

--- a/templates/form/paypalpayments.liquid
+++ b/templates/form/paypalpayments.liquid
@@ -1,7 +1,10 @@
 <div class="container">
-  <form action="{{ model.redirect_url }}" method="GET" target="_top" class="autosubmit">
+  <form action="paypal_jsdk">
+    <div id="paypal-button-container"></div>
+  </form>
+  <form method="GET" target="_top" id="redirect-form" style="visibility:hidden;">
     {% for field in model.params %}
-      <input type="hidden" name="{{ field[0] }}" value='{{ field[1] }}' />
+      <input type="hidden" name="{{ field[0] }}" value="{{ field[1] }}" />
     {% endfor %}
 
     <div class="row">


### PR DESCRIPTION
Added the changes needed for using PayPal's Javascript-SDK

* Added `paypal-button-container` to contain the generated PayPal buttons.
* Removed `redirect_url` as action on `redirect_form` since it is not known when this page is loaded but will be fetched by the javascript calling the JSDK.
* Made `visibility:hidden` for `redirect_form`. The visibility will change if the JSDK fails to load.