### PR TITLE
Added max-height to paypal button, to avoid jumping of logo

### DIFF
--- a/stylesheets/paymentwindow.css
+++ b/stylesheets/paymentwindow.css
@@ -511,3 +511,12 @@ h4 img.icon {
   width: 100%;
   height: 42px;
 }
+
+/*
+ * PayPal Payments
+ *
+ */
+
+.paypal-buttons {
+  max-height: 55px;
+}


### PR DESCRIPTION
Added max-height to Paypal Payments button. 

When the logo is rendered by the JS, the PayPal logo/button is initially set to 100px, before updated to 55px.
This time period results in the logo changing position after load. 

Setting max-height to the PayPal button makes sure it remains stable during loading.

### Before video

https://github.com/QuickPay/standard-branding/assets/3851988/eab8955b-454c-47ef-ac70-d5e0e8e3320d

### After video

https://github.com/QuickPay/standard-branding/assets/3851988/43a963dc-dabc-48a2-bbf9-5cbc7c299cc2





