### PR TITLE
fix: remove fuzzy flag from 'Expires in' translations

### DIFF
--- a/locales/da_DK/LC_MESSAGES/branding.po
+++ b/locales/da_DK/LC_MESSAGES/branding.po
@@ -322,7 +322,6 @@ msgid "Order number"
 msgstr "Ordrenummer"
 
 #: templates/order_info.liquid:8
-#, fuzzy
 msgid "Expires in"
 msgstr "udløber om"
 

--- a/locales/de_DE/LC_MESSAGES/branding.po
+++ b/locales/de_DE/LC_MESSAGES/branding.po
@@ -324,7 +324,6 @@ msgid "Order number"
 msgstr "Bestellnummer"
 
 #: templates/order_info.liquid:8
-#, fuzzy
 msgid "Expires in"
 msgstr "läuft ab in"
 

--- a/locales/es_ES/LC_MESSAGES/branding.po
+++ b/locales/es_ES/LC_MESSAGES/branding.po
@@ -342,7 +342,6 @@ msgid "Order number"
 msgstr "Número de orden"
 
 #: templates/order_info.liquid:8
-#, fuzzy
 msgid "Expires in"
 msgstr "expira en"
 

--- a/locales/fr_FR/LC_MESSAGES/branding.po
+++ b/locales/fr_FR/LC_MESSAGES/branding.po
@@ -340,7 +340,6 @@ msgid "Order number"
 msgstr "Numéro de commande"
 
 #: templates/order_info.liquid:8
-#, fuzzy
 msgid "Expires in"
 msgstr "Expire le"
 

--- a/locales/fr_FR/LC_MESSAGES/branding.po
+++ b/locales/fr_FR/LC_MESSAGES/branding.po
@@ -341,7 +341,7 @@ msgstr "Numéro de commande"
 
 #: templates/order_info.liquid:8
 msgid "Expires in"
-msgstr "Expire le"
+msgstr "Expire dans"
 
 #: templates/success.liquid:4
 msgid "You have completed the payout"

--- a/locales/it_IT/LC_MESSAGES/branding.po
+++ b/locales/it_IT/LC_MESSAGES/branding.po
@@ -338,7 +338,6 @@ msgid "Order number"
 msgstr "Ordine numero"
 
 #: templates/order_info.liquid:8
-#, fuzzy
 msgid "Expires in"
 msgstr "scade tra"
 

--- a/locales/nl_NL/LC_MESSAGES/branding.po
+++ b/locales/nl_NL/LC_MESSAGES/branding.po
@@ -336,7 +336,6 @@ msgid "Order number"
 msgstr "Order nummer"
 
 #: templates/order_info.liquid:8
-#, fuzzy
 msgid "Expires in"
 msgstr "verloopt in"
 

--- a/locales/no_NO/LC_MESSAGES/branding.po
+++ b/locales/no_NO/LC_MESSAGES/branding.po
@@ -322,7 +322,6 @@ msgid "Order number"
 msgstr "Ordrenummer"
 
 #: templates/order_info.liquid:8
-#, fuzzy
 msgid "Expires in"
 msgstr "utløper om"
 

--- a/locales/sv_SE/LC_MESSAGES/branding.po
+++ b/locales/sv_SE/LC_MESSAGES/branding.po
@@ -322,7 +322,6 @@ msgid "Order number"
 msgstr "Ordernummer"
 
 #: templates/order_info.liquid:8
-#, fuzzy
 msgid "Expires in"
 msgstr "utgår om"
 


### PR DESCRIPTION
### Problem

All language translations for "Expires in" were marked with the `#, fuzzy` flag, this caused to always fallback to english translation

## Solution
Removed `#, fuzzy` flag from verified translations within the .po files.

## Languages verified
- Danish (da)
- German (de)
- Spanish (es)
- French (fr) - Translation updated
- Italian (it)
- Norwegian (no)
- Dutch (nl)
- Swedish (sv)